### PR TITLE
Correct message broadcasting

### DIFF
--- a/src/main/java/com/mcbouncer/bukkit/BukkitServer.java
+++ b/src/main/java/com/mcbouncer/bukkit/BukkitServer.java
@@ -105,17 +105,11 @@ public class BukkitServer extends JavaPlugin implements LocalServer {
         }
     }
 
-    public void messageMods(String string) {
-        for (Player player : this.getServer().getOnlinePlayers()) {
-            if (player.hasPermission("mcbouncer.mod")) {
-                player.sendMessage(string);
-            }
-        }
+    public void messageMods(String message) {
+        this.getServer().broadcast(message, "mcbouncer.mod");
     }
 
     public void broadcastMessage(String message) {
-        for (Player player : this.getServer().getOnlinePlayers()) {
-            player.sendMessage(message);
-        }
+        this.getServer().broadcastMessage(message);
     }
 }


### PR DESCRIPTION
Use Server.broadcast() and Server.broadcastMessage() instead of looping through all players for message broadcasting.
This fixes an issue with my IRC plugin not receiving join messages.
